### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/wheeljack/config.py
+++ b/wheeljack/config.py
@@ -38,7 +38,7 @@ def get_config(config):
     else:
         try:
             with open(get_config_filename(), 'r') as stream:
-                __config = yaml.load(stream)
+                __config = yaml.safe_load(stream)
         except IOError:
             raise ReposConfigException("{} could not be opened.".format(
                 get_config_filename()


### PR DESCRIPTION
yaml.safe_load is safe to use in any situation. yaml.load can cause code execution which is not desirable since we are just parsing a config file.

See more details on yaml.load here: https://tools.cisco.com/security/center/viewAlert.x?alertId=58783